### PR TITLE
fix: do not run all checks for the whole entity if target is a file

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -31,7 +31,8 @@ module.exports = inherit({
 
         this._basedir = PATH.resolve(opts.basedir);
 
-        this._targets = this._formatTargets(targets);
+        this._targets = this._prepareTargets(targets);
+        this._formattedTargets = this._formatTargets(this._targets);
         this._levels = opts.levels;
 
         this._excludePaths = this._formatExcludedPaths(opts.excludePaths);
@@ -43,25 +44,28 @@ module.exports = inherit({
 
     /**
      * @param {String[]} targets
+     * @returns {Object[]}
+     */
+    _prepareTargets(targets) {
+        return _(targets || [])
+            .uniq()
+            .map((target) => ({path: target, isFile: fs.statSync(target).isFile()}))
+            .value();
+    },
+
+    /**
+     * @param {Object[]} targets
      * @returns {String[]}
      * @private
      *
      * @example
-     * /some.blocks/some-block/some-block.ext –> /some.block/some-block/some-block.*
-     * /some.blocks/some-block/__some-elem –> /some.blocks/some-block/__some-elem/**
+     * {isFile: true, path: /some.blocks/some-block/some-block.ext} –> /some.block/some-block/some-block.*
+     * {isFile: false, path: /some.blocks/some-block/__some-elem} –> /some.blocks/some-block/__some-elem/**
      */
     _formatTargets: function(targets) {
-        targets = targets || [];
-
-        return _(targets)
-            .map(formatTarget_)
-            .uniq()
-            .value();
-
-        ///
-        function formatTarget_(target) {
-            return fs.statSync(target).isFile() ? utils.replaceTech(target, '*') : PATH.join(target, '**');
-        }
+        return (targets || []).map((target) => {
+            return target.isFile ? utils.replaceTech(target.path, '*') : PATH.join(target.path, '**');
+        });
     },
 
     /**
@@ -78,7 +82,7 @@ module.exports = inherit({
      * @public
      */
     getLevels: function() {
-        return bluebird.map(this._targets, (target) => {
+        return bluebird.map(this._formattedTargets, (target) => {
                 var lastLevelInTarget = this._getLastLevelInTarget(target);
 
                 // if target is file mask
@@ -155,7 +159,7 @@ module.exports = inherit({
      * @public
      */
     isTargetPath: function(path) {
-        return utils.someMinimatch(this._targets, path);
+        return utils.someMinimatch(this._formattedTargets, path);
     },
 
     /**
@@ -179,7 +183,7 @@ module.exports = inherit({
                 return [].concat(config).map(function(userConfig) {
                     return userConfig && new Plugin(path, {
                         userConfig: userConfig,
-                        baseConfig: {configDir: this._basedir}
+                        baseConfig: {configDir: this._basedir, targets: this._targets}
                     });
                 }, this);
             }, this)

--- a/lib/plugin/config.js
+++ b/lib/plugin/config.js
@@ -19,7 +19,9 @@ module.exports = inherit({
      */
     __constructor: function(path, options) {
         this._path = path;
-        this._baseConfig = options.baseConfig;
+        this._baseConfig = options.baseConfig || {};
+
+        this._targets = this._formatTargets(this._baseConfig.targets);
 
         this._config = options.userConfig && _.merge(
             {},
@@ -28,6 +30,15 @@ module.exports = inherit({
         );
 
         this._normalizeTechsConfigs();
+    },
+
+    /**
+     * @param {Object[]} targets
+     * @returns {String[]}
+     * @private
+     */
+    _formatTargets: function(targets) {
+        return (targets || []).map((target) => target.isFile ? target.path : PATH.join(target.path, '**'));
     },
 
     /**
@@ -85,6 +96,14 @@ module.exports = inherit({
      */
     getConfig: function() {
         return this._config;
+    },
+
+    /**
+     * @returns {Boolean}
+     * @public
+     */
+    isTargetTech: function(path) {
+        return utils.someMinimatch(this._targets, path);
     },
 
     /**

--- a/lib/plugin/index.js
+++ b/lib/plugin/index.js
@@ -40,7 +40,7 @@ module.exports = inherit({
                 && promises.push(module.forEachEntity(entity, config));
 
             module.forEachTech && techs.forEach(function(tech) {
-                config.getTechConfig(tech.name) && !config.isExcludedPath(tech.path)
+                config.isTargetTech(tech.path) && config.getTechConfig(tech.name) && !config.isExcludedPath(tech.path)
                     && promises.push(module.forEachTech(tech, entity, config));
             });
         });

--- a/test/config.js
+++ b/test/config.js
@@ -9,26 +9,26 @@ var mockFs = require('mock-fs'),
 describe('Config.prototype', () => {
     let config;
 
-    describe('.getLevels', () => {
-        beforeEach(() => {
-            mockFs({
-                '/some-lib': {
-                    'some.blocks': {
-                        'blocks': {
-                            'block.ext': 'foo'
-                        }
-                    },
-                    'some.other': {
-                        'other.ext': 'bar'
+    beforeEach(() => {
+        mockFs({
+            '/some-lib': {
+                'some.blocks': {
+                    'blocks': {
+                        'block.ext': 'foo'
                     }
+                },
+                'some.other': {
+                    'other.ext': 'bar'
                 }
-            });
+            }
         });
+    });
 
-        afterEach(() => {
-            mockFs.restore();
-        });
+    afterEach(() => {
+        mockFs.restore();
+    });
 
+    describe('.getLevels', () => {
         describe('file target', () => {
             it('should get last level in target', () => {
                 config = new Config(['/some-lib/some.blocks/blocks/block.ext'], {
@@ -240,7 +240,7 @@ describe('Config.prototype', () => {
             resolve.sync.should.be.calledWith('some-plugin', {basedir: '/base/dir'});
             Plugin.prototype.__constructor.should.be.calledWith('/base/dir/node_modules/some-plugin', {
                 userConfig: true,
-                baseConfig: {configDir: '/base/dir'}
+                baseConfig: {configDir: '/base/dir', targets: []}
             });
         });
 
@@ -256,6 +256,22 @@ describe('Config.prototype', () => {
             Plugin.prototype.__constructor.should.be.calledTwice;
             Plugin.prototype.__constructor.should.be.calledWithMatch(sinon.match.any, {userConfig: {foo: true}});
             Plugin.prototype.__constructor.should.be.calledWithMatch(sinon.match.any, {userConfig: {bar: true}});
+        });
+
+        it('should require plugin with prepared targets', () => {
+            config = new Config(['/some-lib/some.blocks/blocks', '/some-lib/some.other/other.ext'],
+                {plugins: {'some-plugin': true}});
+
+            config.requirePlugins();
+
+            Plugin.prototype.__constructor.should.be.calledWith(sinon.match.any, sinon.match({
+                baseConfig: {
+                    targets: [
+                        {isFile: false, path: '/some-lib/some.blocks/blocks'},
+                        {isFile: true, path: '/some-lib/some.other/other.ext'}
+                    ]
+                }
+            }));
         });
     });
 });

--- a/test/plugin/config.js
+++ b/test/plugin/config.js
@@ -7,7 +7,7 @@ describe('PluginConfig', function() {
             {
                 predefinedConfig: opts.predefinedConfig,
                 userConfig: opts.hasOwnProperty('customConfig') ? opts.customConfig : true,
-                baseConfig: opts.baseConfig
+                baseConfig: opts.baseConfig || {}
             }
         );
     }
@@ -53,7 +53,7 @@ describe('PluginConfig', function() {
 
     describe('techs config', function() {
         function createTechsConfig(techsConfigs) {
-            return new PluginConfig('some-path', {userConfig: {techs: techsConfigs}}, {});
+            return new PluginConfig('some-path', {userConfig: {techs: techsConfigs}, baseConfig: {}});
         }
 
         it('should properly work for `{*: true}`', function() {


### PR DESCRIPTION
**Before**:

If we run

```bash
bemhint common.blocks/button/button.js
```

each file of the entity `button` (*button.js*, *button.css*) is checked by plugins with `forEachTech` implementation.

**After**:

only file *button.js* is checked by plugins with `forEachTech` implemetation.